### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/PMDDotNETCompilerUnitTest/PMDDotNETCompilerUnitTest.csproj
+++ b/PMDDotNETCompilerUnitTest/PMDDotNETCompilerUnitTest.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="3.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="3.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="coverlet.collector" Version="1.2.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@aosoft, I found an issue in the PMDDotNETCompilerUnitTest.csproj:

Packages Microsoft.Extensions.Logging v3.1.3, Microsoft.Extensions.Logging.Console v3.1.3, Microsoft.Extensions.Logging.TraceSource v3.1.3, Microsoft.NET.Test.Sdk v16.5.0, MSTest.TestAdapter v2.1.0, MSTest.TestFramework v2.1.0, coverlet.collector v1.2.0 and System.Text.Encoding.CodePages v4.7.0 transitively introduce 90 dependencies into PMDDotNET’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/PMDDotNET.html)), while Microsoft.Extensions.Logging v3.1.14, Microsoft.Extensions.Logging.Console v3.1.5, Microsoft.Extensions.Logging.TraceSource v3.1.4, Microsoft.NET.Test.Sdk v16.6.1, MSTest.TestAdapter v2.2.1, MSTest.TestFramework v2.1.2, System.Text.Encoding.CodePages v4.7.1 and coverlet.collector v1.2.1 can only introduce 58 dependencies ([see dependency graph after upgrades)](http://202.182.124.107:8000/PMDDotNET_after.html).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose